### PR TITLE
Fix bad type check for lua files

### DIFF
--- a/startup.lua
+++ b/startup.lua
@@ -32,7 +32,7 @@ local function loadPages()
 
         local ok, data = pcall(dofile, path)
 
-        if not ok or type(data) ~= table then
+        if not ok or type(data) ~= "table" then
             print("Failed to load page:", file)
             return
         end


### PR DESCRIPTION
The startup file uses `type(data) ~= table`, which is wrong.
Since `table` is not having any double quotes around it to make it a string, is Lua seeing it as an object (that in this case would be `nil`), which makes this check fail.

Simply wrapping it in strings fixes this.